### PR TITLE
Proposal: Changes to `BookmarkCard.kt`

### DIFF
--- a/app/src/main/java/de/readeckapp/ui/list/BookmarkCard.kt
+++ b/app/src/main/java/de/readeckapp/ui/list/BookmarkCard.kt
@@ -1,22 +1,33 @@
 package de.readeckapp.ui.list
 
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckBox
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Grade
 import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.CheckBoxOutlineBlank
+import androidx.compose.material.icons.outlined.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Grade
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material3.Card
@@ -27,15 +38,20 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
@@ -52,10 +68,12 @@ import coil3.compose.LocalAsyncImagePreviewHandler
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import com.google.android.material.chip.Chip
 import de.readeckapp.R
 import de.readeckapp.domain.model.Bookmark
 import de.readeckapp.domain.model.BookmarkListItem
 import de.readeckapp.ui.components.ErrorPlaceholderImage
+import timber.log.Timber
 
 @Composable
 fun BookmarkCard(
@@ -83,7 +101,9 @@ fun BookmarkCard(
                 contentScale = ContentScale.FillWidth,
                 error = {
                     ErrorPlaceholderImage(
-                        modifier = Modifier.fillMaxWidth().height(200.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp),
                         imageContentDescription = stringResource(R.string.common_bookmark_image_content_description)
                     )
                 },
@@ -117,6 +137,107 @@ fun BookmarkCard(
 
                 }
 
+                if(bookmark.labels.isNotEmpty()){
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    ){
+                        Icon(
+                            painter = painterResource(R.drawable.ic_label_24px),
+                            contentDescription = "labels"
+                        )
+                        Spacer(Modifier.width(8.dp))
+
+                        FadingLabelRow(items = bookmark.labels)
+                    }
+                }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                ){
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(
+                            onClick = {
+                                onClickFavorite(bookmark.id, !bookmark.isMarked)
+                            }
+                        ){
+                            Icon(
+                                imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                                contentDescription = stringResource(R.string.action_favorite),
+                                modifier = Modifier.alpha(if(bookmark.isMarked) 1f else 0.5f)
+                            )
+                        }
+
+                        IconButton(
+                            onClick = {
+                                onClickArchive(bookmark.id, !bookmark.isArchived)
+                            }
+                        ){
+                            Icon(
+                                imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                                contentDescription = stringResource(R.string.action_archive),
+                                modifier = Modifier.alpha(if(bookmark.isArchived) 1f else 0.5f)
+
+                            )
+                        }
+
+
+                    }
+
+                    Spacer(Modifier.weight(1f))
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(
+                            onClick = {
+                                expanded = true
+                            },
+                        ) {
+                            Icon(Icons.Filled.MoreVert, contentDescription = "Actions")
+                        }
+                        DropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = { expanded = false }
+                        ) {
+
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.action_mark_read)) },
+                                onClick = {
+                                    onClickMarkRead(bookmark.id, !bookmark.isRead)
+                                    expanded = false
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = if (bookmark.isRead) Icons.Filled.CheckBox else Icons.Outlined.CheckBoxOutlineBlank,
+                                        contentDescription = stringResource(R.string.action_mark_read)
+                                    )
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.action_delete)) },
+                                onClick = {
+                                    onClickDelete(bookmark.id)
+                                    expanded = false
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Filled.Delete,
+                                        contentDescription = stringResource(R.string.action_delete)
+                                    )
+                                }
+                            )
+                        }
+                    }
+
+                }
+
+
+                /*
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
@@ -150,74 +271,74 @@ fun BookmarkCard(
                     Box(
                         contentAlignment = Alignment.BottomEnd
                     ) {
-                        IconButton(
-                            onClick = {
-                                expanded = true
-                            },
-                        ) {
-                            Icon(Icons.Filled.MoreVert, contentDescription = "Actions")
-                        }
-                        DropdownMenu(
-                            expanded = expanded,
-                            onDismissRequest = { expanded = false }
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.action_favorite)) },
-                                onClick = {
-                                    onClickFavorite(bookmark.id, !bookmark.isMarked)
-                                    expanded = false
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = if (bookmark.isMarked) Icons.Filled.Grade else Icons.Outlined.Grade,
-                                        contentDescription = stringResource(R.string.action_favorite)
-                                    )
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.action_archive)) },
-                                onClick = {
-                                    onClickArchive(bookmark.id, !bookmark.isArchived)
-                                    expanded = false
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
-                                        contentDescription = stringResource(R.string.action_archive)
-                                    )
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.action_mark_read)) },
-                                onClick = {
-                                    onClickMarkRead(bookmark.id, !bookmark.isRead)
-                                    expanded = false
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = if (bookmark.isRead) Icons.Filled.CheckBox else Icons.Outlined.CheckBoxOutlineBlank,
-                                        contentDescription = stringResource(R.string.action_mark_read)
-                                    )
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.action_delete)) },
-                                onClick = {
-                                    onClickDelete(bookmark.id)
-                                    expanded = false
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        Icons.Filled.Delete,
-                                        contentDescription = stringResource(R.string.action_delete)
-                                    )
-                                }
-                            )
-                        }
+
                     }
-                }
+                }*/
 
             }
+        }
+    }
+}
+
+@Composable
+fun FadingLabelRow(items: List<String>) {
+    val scrollState = rememberScrollState()
+    val endFadeWidth = 48.dp
+    val minRowHeight = 24.dp
+
+    // Calculate alpha value based on scrollState
+    val fadeAlpha by remember {
+        derivedStateOf {
+            if (scrollState.maxValue == 0) {
+                0f
+            } else {
+                val remainingScroll = scrollState.maxValue - scrollState.value
+                (remainingScroll.toFloat() / (endFadeWidth.value * 2)).coerceIn(0f, 1f)
+            }
+        }
+    }
+
+    Box (
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+    ) {
+        // the actual Row with the label chips
+        Row(
+            modifier = Modifier
+                .horizontalScroll(scrollState)
+                .padding(end = endFadeWidth)
+        ) {
+            items.forEach {item ->
+                SuggestionChip(
+                    onClick = {},
+                    label = { Text(
+                        item,
+                        style = MaterialTheme.typography.labelLarge
+                    ) },
+                    modifier = Modifier
+                        .padding(horizontal = 4.dp)
+                        .height(minRowHeight)
+                )
+            }
+        }
+        // add a Box with a gradient if there's still scrollable area
+        if (fadeAlpha > 0f) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .width(endFadeWidth)
+                    .fillMaxHeight()
+                    .alpha(fadeAlpha)
+                    .background(
+                        brush = Brush.horizontalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                MaterialTheme.colorScheme.surfaceContainerHighest
+                            )
+                        )
+                    )
+            )
         }
     }
 }


### PR DESCRIPTION
This is a rough draft and and would obviously need some fine-tuning, but maybe it's something you're interested in:

https://github.com/user-attachments/assets/468b5de5-b583-443b-866e-c16222c15cfd

## 1) Display Labels as Chips
- Displaying labels as Chips would allow for easy filtering in the `BookmarkListScreen` later down the line —users could simply tap a Chip to filter by that label.
- To support a larger number of labels, the Chip row could be horizontally scrollable. A gradient at the end of the row could indicate that more content is available by scrolling.

## 2) Move Frequently used actions out of the Three-Dot Menu
- This should be fairly self-explanatory: frequently used actions should be accessible directly, without requiring users to open a menu.
- Of course, this change requires some fine-tuning of the layout, especially the spacing in the action row.

What do you think?