### PR TITLE
Trust user-installed CA certificates

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true"/>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
With this PR, the app will trust user-added CA certificates.
This lets users connect to servers that use self-signed certificates.
Typical use case: deployments behind a VPN with custom DNS ([tailscale](https://tailscale.com) _et al_).

Fixes issue #105

Known issues:
- Exposes users to MitM attacks should they install malicious CA certificates.

Similar issues in other apps:
- [Karakeep](https://github.com/karakeep-app/karakeep/pull/416)
- [Shiori](https://github.com/DesarrolloAntonio/Shiori-Android-Client/pull/54)