### PR TITLE
fix: missing reading progress synchronization when using system back press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed missing synchronization of reading progress when using system back press (gesture or back button). Closes #159.
 - Fixed some untranslated strings.
 - Fixed misleading url field. Closes #158.
 

--- a/app/src/main/java/de/readeckapp/ui/detail/BookmarkDetailScreen.kt
+++ b/app/src/main/java/de/readeckapp/ui/detail/BookmarkDetailScreen.kt
@@ -3,6 +3,7 @@ package de.readeckapp.ui.detail
 import android.icu.text.MessageFormat
 import android.view.View
 import android.webkit.WebView
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -122,6 +123,8 @@ fun BookmarkDetailScreen(navHostController: NavController, bookmarkId: String?) 
             viewModel.onNavigationEventConsumed()
         }
     }
+
+    BackHandler { onClickBack() }
 
     val context = LocalContext.current
     LaunchedEffect(key1 = openUrlEvent.value){


### PR DESCRIPTION
handle system back presses like the click on the back button in the top appbar