### PR TITLE
fix: handle Int overflow in ImageResource deserialization (#174)

### DIFF
--- a/app/src/main/java/de/readeckapp/domain/mapper/BookmarkMapper.kt
+++ b/app/src/main/java/de/readeckapp/domain/mapper/BookmarkMapper.kt
@@ -169,6 +169,6 @@ fun ResourceDto?.toDomain(): Bookmark.Resource = Bookmark.Resource(
 
 fun ImageResourceDto?.toDomain(): Bookmark.ImageResource = Bookmark.ImageResource(
     src = this?.src ?: "",
-    width = this?.width ?: 0,
-    height = this?.height ?: 0
+    width = this?.width?.coerceIn(0, Int.MAX_VALUE.toLong())?.toInt() ?: 0,
+    height = this?.height?.coerceIn(0, Int.MAX_VALUE.toLong())?.toInt() ?: 0
 )

--- a/app/src/main/java/de/readeckapp/io/rest/model/BookmarkDto.kt
+++ b/app/src/main/java/de/readeckapp/io/rest/model/BookmarkDto.kt
@@ -61,6 +61,6 @@ data class Resource(
 @Serializable
 data class ImageResource(
     val src: String,
-    val width: Int? = null,
-    val height: Int? = null,
+    val width: Long? = null,
+    val height: Long? = null,
 )

--- a/app/src/test/java/de/readeckapp/io/rest/ReadeckApiTest.kt
+++ b/app/src/test/java/de/readeckapp/io/rest/ReadeckApiTest.kt
@@ -172,6 +172,23 @@ class ReadeckApiTest {
         assertEquals("Unauthorized", statusMessage.message)
     }
 
+    @Test
+    fun testGetBookmarksWithOverflowImageDimensions() = runTest {
+        mockWebServer.enqueue(MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_OK)
+            .addHeader("Content-Type", "application/json")
+            .setBody(loadJsonFromClasspath("api/bookmarks-overflow-image.json"))
+        )
+
+        val response = readeckApi.getBookmarks(10, 0, null, ReadeckApi.SortOrder(ReadeckApi.Sort.Created))
+
+        assertTrue(response.isSuccessful)
+        assertEquals(1, response.body()?.size)
+        val bookmark = response.body()!![0]
+        assertEquals(Long.MIN_VALUE, bookmark.resources.image?.width)
+        assertEquals(Long.MIN_VALUE, bookmark.resources.image?.height)
+    }
+
     private fun loadJsonFromClasspath(resourcePath: String): String {
         val inputStream = this.javaClass.classLoader?.getResourceAsStream(resourcePath)
             ?: throw IllegalArgumentException("Resource not found: $resourcePath")

--- a/app/src/test/resources/api/bookmarks-overflow-image.json
+++ b/app/src/test/resources/api/bookmarks-overflow-image.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "OverflowImageWidth123",
+    "href": "https://readeck.example.com/api/bookmarks/OverflowImageWidth123",
+    "created": "2025-04-03T19:00:13.646333268Z",
+    "updated": "2025-04-04T14:09:22.615018537Z",
+    "state": 0,
+    "loaded": true,
+    "url": "https://example.com/blog/overflow",
+    "title": "Bookmark with overflow image dimensions",
+    "site_name": "example.com",
+    "site": "example.com",
+    "authors": [],
+    "lang": "",
+    "text_direction": "",
+    "document_type": "article",
+    "type": "article",
+    "has_article": true,
+    "description": "This bookmark has Long.MIN_VALUE as image width",
+    "is_deleted": false,
+    "is_marked": false,
+    "is_archived": false,
+    "labels": [],
+    "read_progress": 0,
+    "resources": {
+      "article": {
+        "src": "https://readeck.example.com/api/bookmarks/OverflowImageWidth123/article"
+      },
+      "icon": {
+        "src": "https://readeck.example.com/bm/Ov/OverflowImageWidth123/img/icon.png",
+        "width": 48,
+        "height": 48
+      },
+      "image": {
+        "src": "https://readeck.example.com/bm/Ov/OverflowImageWidth123/img/image.png",
+        "width": -9223372036854775808,
+        "height": -9223372036854775808
+      },
+      "log": {
+        "src": "https://readeck.example.com/api/bookmarks/OverflowImageWidth123/x/log"
+      },
+      "props": {
+        "src": "https://readeck.example.com/api/bookmarks/OverflowImageWidth123/x/props.json"
+      },
+      "thumbnail": {
+        "src": "https://readeck.example.com/bm/Ov/OverflowImageWidth123/img/thumbnail.png",
+        "width": 380,
+        "height": 190
+      }
+    },
+    "word_count": 100,
+    "reading_time": 1
+  }
+]


### PR DESCRIPTION
## Summary

Fixes #174 — Initial sync fails silently when any bookmark has image dimensions that overflow `Int`.

I had wrongly diagnosed the  root cause in the issue above.

## Root Cause

The Readeck server can store image resource dimensions as 64-bit integers (e.g., sentinel values like `Long.MIN_VALUE` for unknown dimensions). The `ImageResource` DTO declared `width`/`height` as `Int?`, causing a `JsonDecodingException` when any bookmark in the response contains a value outside the 32-bit integer range.

Since `LoadBookmarksUseCase` fetches bookmarks in pages, the entire sync aborts when it hits the page containing the problematic bookmark. No error is surfaced to the user — the app appears to have synced successfully but with incomplete data.

This affects any user whose library contains at least one bookmark where the server stored an out-of-range image dimension.

## Fix

- Changed `ImageResource` DTO `width`/`height` from `Int?` to `Long?` to accept any value the server returns
- Added safe coercion in the mapper: clamp negative or oversized values to `0..Int.MAX_VALUE` before converting to `Int`

## Testing

Tested on a Readeck 0.22.2 instance with 2,854 bookmarks. Before the fix, sync crashed at page 26. After the fix, all pages load successfully.