### PR TITLE
feat: add e-ink mode setting with tap-to-scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added e-ink mode setting. When enabled, navigation transitions and image crossfade are disabled, and tap zones (tap the top or bottom half of the screen) allow paging through articles without scrolling. Intended for e-ink readers.
+
 ### Changed
 
 - Changed the way unread bookmarks are determined. The behavior now matches that of the Readeck web app. This means that unread bookmarks are bookmarks that have not been archived. Closes #166 and #169.

--- a/app/src/main/assets/html_template_eink.html
+++ b/app/src/main/assets/html_template_eink.html
@@ -1,0 +1,220 @@
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
+    <style>
+        /* Body */
+        html {
+          font-size: 62.5%;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        }
+
+        body {
+          font-size: 1.8rem;
+          font-weight: 500;
+          line-height: 1.618;
+          max-width: 38em;
+          margin: auto;
+          color: #000000;
+          background-color: #ffffff;
+          padding: 13px;
+        }
+
+        @media (max-width: 684px) {
+          body {
+            font-size: 1.53rem;
+          }
+        }
+        @media (max-width: 382px) {
+          body {
+            font-size: 1.35rem;
+          }
+        }
+        h1, h2, h3, h4, h5, h6 {
+          line-height: 1.1;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+          font-weight: 700;
+          margin-top: 3rem;
+          margin-bottom: 1.5rem;
+          overflow-wrap: break-word;
+          word-wrap: break-word;
+          -ms-word-break: break-all;
+          word-break: break-word;
+        }
+
+        h1 { font-size: 2.35em; }
+        h2 { font-size: 2em; }
+        h3 { font-size: 1.75em; }
+        h4 { font-size: 1.5em; }
+        h5 { font-size: 1.25em; }
+        h6 { font-size: 1em; }
+
+        p {
+          margin-top: 0px;
+          margin-bottom: 2.5rem;
+        }
+
+        small, sub, sup {
+          font-size: 75%;
+        }
+
+        hr {
+          border-color: #000000;
+        }
+
+        a {
+          text-decoration: underline;
+          color: #000000;
+        }
+        a:visited {
+          color: #000000;
+        }
+        a:hover {
+          color: #000000;
+        }
+
+        ul {
+          padding-left: 1.4em;
+          margin-top: 0px;
+          margin-bottom: 2.5rem;
+        }
+
+        li {
+          margin-bottom: 0.4em;
+        }
+
+        blockquote {
+          margin-left: 0px;
+          margin-right: 0px;
+          padding-left: 1em;
+          padding-top: 0.8em;
+          padding-bottom: 0.8em;
+          padding-right: 0.8em;
+          border-left: 5px solid #000000;
+          margin-bottom: 2.5rem;
+          background-color: transparent;
+        }
+
+        blockquote p {
+          margin-bottom: 0;
+        }
+
+        img, video {
+          height: auto;
+          max-width: 100%;
+          margin-top: 0px;
+          margin-bottom: 2.5rem;
+        }
+
+        /* Pre and Code */
+        pre {
+          background-color: #eeeeee;
+          display: block;
+          padding: 1em;
+          overflow-x: auto;
+          margin-top: 0px;
+          margin-bottom: 2.5rem;
+          font-size: 0.9em;
+        }
+
+        code, kbd, samp {
+          font-size: 0.9em;
+          font-weight: 500;
+          padding: 0 0.5em;
+          background-color: #eeeeee;
+          white-space: pre-wrap;
+        }
+
+        pre > code {
+          padding: 0;
+          background-color: transparent;
+          white-space: pre;
+          font-size: 1em;
+        }
+
+        /* Tables */
+        table {
+          text-align: justify;
+          width: 100%;
+          border-collapse: collapse;
+          margin-bottom: 2rem;
+        }
+
+        td, th {
+          padding: 0.5em;
+          border-bottom: 1px solid #000000;
+        }
+
+        /* Buttons, forms and input */
+        input, textarea {
+          border: 1px solid #000000;
+        }
+        input:focus, textarea:focus {
+          border: 1px solid #000000;
+        }
+
+        textarea {
+          width: 100%;
+        }
+
+        .button, button, input[type=submit], input[type=reset], input[type=button], input[type=file]::file-selector-button {
+          display: inline-block;
+          padding: 5px 10px;
+          text-align: center;
+          text-decoration: none;
+          white-space: nowrap;
+          background-color: #000000;
+          color: #ffffff;
+          border-radius: 0;
+          border: 1px solid #000000;
+          cursor: pointer;
+          box-sizing: border-box;
+        }
+        .button[disabled], button[disabled], input[type=submit][disabled], input[type=reset][disabled], input[type=button][disabled], input[type=file]::file-selector-button[disabled] {
+          cursor: default;
+          opacity: 0.5;
+        }
+        .button:hover, button:hover, input[type=submit]:hover, input[type=reset]:hover, input[type=button]:hover, input[type=file]::file-selector-button:hover {
+          background-color: #000000;
+          color: #ffffff;
+          outline: 0;
+        }
+        .button:focus-visible, button:focus-visible, input[type=submit]:focus-visible, input[type=reset]:focus-visible, input[type=button]:focus-visible, input[type=file]::file-selector-button:focus-visible {
+          outline-style: solid;
+          outline-width: 2px;
+        }
+
+        textarea, select, input {
+          color: #000000;
+          padding: 6px 10px;
+          margin-bottom: 10px;
+          background-color: #ffffff;
+          border: 1px solid #000000;
+          border-radius: 0;
+          box-shadow: none;
+          box-sizing: border-box;
+        }
+        textarea:focus, select:focus, input:focus {
+          border: 1px solid #000000;
+          outline: 0;
+        }
+
+        input[type=checkbox]:focus {
+          outline: 1px dotted #000000;
+        }
+
+        label, legend, fieldset {
+          display: block;
+          margin-bottom: 0.5rem;
+          font-weight: 600;
+        }
+
+    </style>
+</head>
+<body>
+    <div class="container">
+        %s
+    </div>
+</body>
+</html>

--- a/app/src/main/java/de/readeckapp/MainActivity.kt
+++ b/app/src/main/java/de/readeckapp/MainActivity.kt
@@ -7,6 +7,11 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -56,6 +61,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val viewModel = hiltViewModel<MainViewModel>()
             val theme = viewModel.theme.collectAsState()
+            val eInkMode = viewModel.eInkMode.collectAsState()
             val navController = rememberNavController()
             intentState = remember { mutableStateOf(intent) }
             val scope = rememberCoroutineScope()
@@ -89,8 +95,8 @@ class MainActivity : ComponentActivity() {
                 else -> theme.value
             }
 
-            ReadeckAppTheme(theme = themeValue) {
-                ReadeckNavHost(navController)
+            ReadeckAppTheme(theme = themeValue, eInkMode = eInkMode.value) {
+                ReadeckNavHost(navController, eInkMode = eInkMode.value)
             }
         }
     }
@@ -103,8 +109,15 @@ class MainActivity : ComponentActivity() {
 
 @SuppressLint("WrongStartDestinationType")
 @Composable
-fun ReadeckNavHost(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = BookmarkListRoute()) {
+fun ReadeckNavHost(navController: NavHostController, eInkMode: Boolean = false) {
+    NavHost(
+        navController = navController,
+        startDestination = BookmarkListRoute(),
+        enterTransition = { if (eInkMode) EnterTransition.None else fadeIn(animationSpec = tween(700)) },
+        exitTransition = { if (eInkMode) ExitTransition.None else fadeOut(animationSpec = tween(700)) },
+        popEnterTransition = { if (eInkMode) EnterTransition.None else fadeIn(animationSpec = tween(700)) },
+        popExitTransition = { if (eInkMode) ExitTransition.None else fadeOut(animationSpec = tween(700)) },
+    ) {
         composable<BookmarkListRoute> { BookmarkListScreen(navController) }
         composable<SettingsRoute> { SettingsScreen(navController) }
         composable<AccountSettingsRoute> { AccountSettingsScreen(navController) }

--- a/app/src/main/java/de/readeckapp/MainViewModel.kt
+++ b/app/src/main/java/de/readeckapp/MainViewModel.kt
@@ -21,4 +21,10 @@ class MainViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = Theme.SYSTEM
     )
+
+    val eInkMode = settingsDataStore.eInkModeFlow.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = false
+    )
 }

--- a/app/src/main/java/de/readeckapp/domain/model/Template.kt
+++ b/app/src/main/java/de/readeckapp/domain/model/Template.kt
@@ -20,5 +20,6 @@ sealed interface Template {
         const val LIGHT_TEMPLATE_FILE = "html_template_light.html"
         const val DARK_TEMPLATE_FILE = "html_template_dark.html"
         const val SEPIA_TEMPLATE_FILE = "html_template_sepia.html"
+        const val EINK_TEMPLATE_FILE = "html_template_eink.html"
     }
 }

--- a/app/src/main/java/de/readeckapp/io/prefs/SettingsDataStore.kt
+++ b/app/src/main/java/de/readeckapp/io/prefs/SettingsDataStore.kt
@@ -13,6 +13,7 @@ interface SettingsDataStore {
     val urlFlow: StateFlow<String?>
     val themeFlow: StateFlow<String?>
     val zoomFactorFlow: StateFlow<Int>
+    val eInkModeFlow: StateFlow<Boolean>
 
     fun saveUsername(username: String)
     fun saveToken(token: String)
@@ -34,6 +35,8 @@ interface SettingsDataStore {
     suspend fun setSyncReadProgressEnabled(enabled: Boolean)
     suspend fun isScrollToProgressEnabled(): Boolean
     suspend fun setScrollToProgressEnabled(enabled: Boolean)
+    suspend fun isEInkModeEnabled(): Boolean
+    suspend fun setEInkModeEnabled(enabled: Boolean)
     suspend fun saveTheme(theme: Theme)
     suspend fun getTheme(): Theme
     suspend fun  getZoomFactor(): Int

--- a/app/src/main/java/de/readeckapp/io/prefs/SettingsDataStoreImpl.kt
+++ b/app/src/main/java/de/readeckapp/io/prefs/SettingsDataStoreImpl.kt
@@ -37,6 +37,7 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
     private val KEY_ZOOM_FACTOR = intPreferencesKey("zoom_factor")
     private val KEY_SYNC_READ_PROGRESS = booleanPreferencesKey("sync_read_progress")
     private val KEY_SCROLL_TO_PROGRESS = booleanPreferencesKey("scroll_to_progress")
+    private val KEY_EINK_MODE = booleanPreferencesKey("eink_mode")
     private val KEY_DEFAULT_FILTER = stringPreferencesKey("default_filter")
 
     override fun saveUsername(username: String) {
@@ -166,6 +167,16 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
         }
     }
 
+    override suspend fun isEInkModeEnabled(): Boolean {
+        return encryptedSharedPreferences.getBoolean(KEY_EINK_MODE.name, false)
+    }
+
+    override suspend fun setEInkModeEnabled(enabled: Boolean) {
+        encryptedSharedPreferences.edit {
+            putBoolean(KEY_EINK_MODE.name, enabled)
+        }
+    }
+
     override suspend fun getDefaultFilter(): DefaultFilter {
         return encryptedSharedPreferences.getString(KEY_DEFAULT_FILTER.name, DefaultFilter.ALL.name)?.let {
             DefaultFilter.valueOf(it)
@@ -184,6 +195,9 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
     override val authStateFlow = getStringFlow(KEY_AUTH_STATE.name, null)
     override val themeFlow = getStringFlow(KEY_THEME.name, Theme.SYSTEM.name)
     override val zoomFactorFlow = getIntFlow(KEY_ZOOM_FACTOR.name, 100)
+    override val eInkModeFlow = preferenceFlow(KEY_EINK_MODE.name) {
+        encryptedSharedPreferences.getBoolean(KEY_EINK_MODE.name, false)
+    }
     
     init {
         // Migration: remove legacy password if it exists

--- a/app/src/main/java/de/readeckapp/ui/detail/BookmarkDetailScreen.kt
+++ b/app/src/main/java/de/readeckapp/ui/detail/BookmarkDetailScreen.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,6 +54,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -60,6 +62,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
@@ -80,6 +83,7 @@ import de.readeckapp.util.openUrlInCustomTab
 import de.readeckapp.ui.components.ShareBookmarkChooser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
@@ -101,6 +105,7 @@ fun BookmarkDetailScreen(navHostController: NavController, bookmarkId: String?) 
     val onProgressUpdate: (Int) -> Unit =
         { progress -> viewModel.onUpdateReadProgress(progress) }
     val scrollToProgressEnabled by viewModel.scrollToProgressEnabledFlow.collectAsState()
+    val eInkMode by viewModel.eInkModeFlow.collectAsState()
 
     val onClickOpenUrl: (String) -> Unit = { viewModel.onClickOpenUrl(it) }
     val onClickShareBookmark: (String) -> Unit = { url -> viewModel.onClickShareBookmark(url) }
@@ -164,7 +169,8 @@ fun BookmarkDetailScreen(navHostController: NavController, bookmarkId: String?) 
                 onClickDecreaseZoomFactor = onClickDecreaseZoomFactor,
                 onProgressUpdate = onProgressUpdate,
                 readProgress = readProgress,
-                scrollToProgressEnabled = scrollToProgressEnabled
+                scrollToProgressEnabled = scrollToProgressEnabled,
+                eInkMode = eInkMode,
             )
             // Consumes a shareIntent and creates the corresponding share dialog
             ShareBookmarkChooser(
@@ -207,6 +213,7 @@ fun BookmarkDetailScreen(
     onProgressUpdate: (Int) -> Unit,
     readProgress: Int,
     scrollToProgressEnabled: Boolean,
+    eInkMode: Boolean,
 ) {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -277,6 +284,7 @@ fun BookmarkDetailScreen(
             uiState = uiState,
             onClickOpenUrl = onClickOpenUrl,
             scrollState = scrollState,
+            eInkMode = eInkMode,
         )
     }
 }
@@ -293,26 +301,45 @@ fun BookmarkDetailContent(
     uiState: BookmarkDetailViewModel.UiState.Success,
     onClickOpenUrl: (String) -> Unit,
     scrollState: ScrollState,
+    eInkMode: Boolean,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(scrollState),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        BookmarkDetailHeader(
-            modifier = Modifier,
-            uiState = uiState,
-            onClickOpenUrl = onClickOpenUrl
-        )
-        if (uiState.bookmark.articleContent != null) {
-            BookmarkDetailArticle(
+    val scope = rememberCoroutineScope()
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState, enabled = !eInkMode),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            BookmarkDetailHeader(
                 modifier = Modifier,
-                uiState = uiState
+                uiState = uiState,
+                onClickOpenUrl = onClickOpenUrl,
+                eInkMode = eInkMode
             )
-        } else {
-            EmptyBookmarkDetailArticle(
-                modifier = Modifier
+            if (uiState.bookmark.articleContent != null) {
+                BookmarkDetailArticle(
+                    modifier = Modifier,
+                    uiState = uiState
+                )
+            } else {
+                EmptyBookmarkDetailArticle(
+                    modifier = Modifier
+                )
+            }
+        }
+        if (eInkMode) {
+            Box(
+                Modifier
+                    .matchParentSize()
+                    .pointerInput(scrollState) {
+                        detectTapGestures { offset ->
+                            val viewport = size.height
+                            val delta = if (offset.y > viewport / 2) viewport else -viewport
+                            val target = (scrollState.value + delta).coerceIn(0, scrollState.maxValue)
+                            scope.launch { scrollState.scrollTo(target) }
+                        }
+                    }
             )
         }
     }
@@ -393,7 +420,8 @@ suspend fun getTemplate(uiState: BookmarkDetailViewModel.UiState.Success, isSyst
 fun BookmarkDetailHeader(
     modifier: Modifier,
     uiState: BookmarkDetailViewModel.UiState.Success,
-    onClickOpenUrl: (String) -> Unit
+    onClickOpenUrl: (String) -> Unit,
+    eInkMode: Boolean = false,
 ) {
     val msg = stringResource(R.string.authors)
     val author = MessageFormat.format(
@@ -409,7 +437,7 @@ fun BookmarkDetailHeader(
         // Header Section Start
         SubcomposeAsyncImage(
             model = ImageRequest.Builder(LocalContext.current).data(uiState.bookmark.imgSrc)
-                .crossfade(true).build(),
+                .crossfade(!eInkMode).build(),
             contentDescription = stringResource(R.string.common_bookmark_image_content_description),
             contentScale = ContentScale.FillWidth,
             error = {
@@ -603,6 +631,7 @@ fun BookmarkDetailScreenPreview() {
         onProgressUpdate = {},
         readProgress = 0,
         scrollToProgressEnabled = true,
+        eInkMode = false,
     )
 }
 
@@ -619,7 +648,8 @@ private fun BookmarkDetailContentPreview() {
                 zoomFactor = 100
             ),
             onClickOpenUrl = {},
-            scrollState = rememberScrollState()
+            scrollState = rememberScrollState(),
+            eInkMode = false,
         )
     }
 }

--- a/app/src/main/java/de/readeckapp/ui/detail/BookmarkDetailViewModel.kt
+++ b/app/src/main/java/de/readeckapp/ui/detail/BookmarkDetailViewModel.kt
@@ -51,27 +51,32 @@ class BookmarkDetailViewModel @Inject constructor(
     val shareIntent: StateFlow<Intent?> = _shareIntent.asStateFlow()
 
     private val bookmarkId: String? = savedStateHandle["bookmarkId"]
-    private val template: Flow<Template?> = settingsDataStore.themeFlow.map {
-        it?.let {
-            Theme.valueOf(it)
-        } ?: Theme.SYSTEM
-    }.map {
-        when (it) {
-            Theme.DARK -> assetLoader.loadAsset(Template.DARK_TEMPLATE_FILE)?.let { Template.SimpleTemplate(it) }
-            Theme.LIGHT -> assetLoader.loadAsset(Template.LIGHT_TEMPLATE_FILE)?.let { Template.SimpleTemplate(it) }
-            Theme.SEPIA -> assetLoader.loadAsset(Template.SEPIA_TEMPLATE_FILE)?.let { Template.SimpleTemplate(it) }
-            Theme.SYSTEM -> {
-                val light = assetLoader.loadAsset(Template.LIGHT_TEMPLATE_FILE)
-                val dark = assetLoader.loadAsset(Template.DARK_TEMPLATE_FILE)
-                if (!light.isNullOrBlank() && !dark.isNullOrBlank()) {
-                    Template.DynamicTemplate(light = light, dark = dark)
-                } else null
+    private val template: Flow<Template?> = combine(
+        settingsDataStore.themeFlow,
+        settingsDataStore.eInkModeFlow
+    ) { themeStr, eInkMode ->
+        if (eInkMode) {
+            assetLoader.loadAsset(Template.EINK_TEMPLATE_FILE)?.let { Template.SimpleTemplate(it) }
+        } else {
+            val theme = themeStr?.let { Theme.valueOf(it) } ?: Theme.SYSTEM
+            when (theme) {
+                Theme.DARK -> assetLoader.loadAsset(Template.DARK_TEMPLATE_FILE)?.let { Template.SimpleTemplate(it) }
+                Theme.LIGHT -> assetLoader.loadAsset(Template.LIGHT_TEMPLATE_FILE)?.let { Template.SimpleTemplate(it) }
+                Theme.SEPIA -> assetLoader.loadAsset(Template.SEPIA_TEMPLATE_FILE)?.let { Template.SimpleTemplate(it) }
+                Theme.SYSTEM -> {
+                    val light = assetLoader.loadAsset(Template.LIGHT_TEMPLATE_FILE)
+                    val dark = assetLoader.loadAsset(Template.DARK_TEMPLATE_FILE)
+                    if (!light.isNullOrBlank() && !dark.isNullOrBlank()) {
+                        Template.DynamicTemplate(light = light, dark = dark)
+                    } else null
+                }
             }
         }
     }
     private val zoomFactor: Flow<Int> = settingsDataStore.zoomFactorFlow
     private var syncReadProgressEnabled: Boolean = true
     private var scrollToProgressEnabled: Boolean = true
+    private var eInkMode: Boolean = false
     private val updateState = MutableStateFlow<UpdateBookmarkState?>(null)
 
     private val _readProgress = MutableStateFlow<Int>(0)
@@ -80,11 +85,16 @@ class BookmarkDetailViewModel @Inject constructor(
     private val _scrollToProgressEnabledFlow = MutableStateFlow(true)
     val scrollToProgressEnabledFlow: StateFlow<Boolean> = _scrollToProgressEnabledFlow.asStateFlow()
 
+    private val _eInkModeFlow = MutableStateFlow(false)
+    val eInkModeFlow: StateFlow<Boolean> = _eInkModeFlow.asStateFlow()
+
     init {
         viewModelScope.launch {
             syncReadProgressEnabled = settingsDataStore.isSyncReadProgressEnabled()
             scrollToProgressEnabled = settingsDataStore.isScrollToProgressEnabled()
             _scrollToProgressEnabledFlow.value = scrollToProgressEnabled
+            eInkMode = settingsDataStore.isEInkModeEnabled()
+            _eInkModeFlow.value = eInkMode
         }
     }
 

--- a/app/src/main/java/de/readeckapp/ui/settings/UiSettingsScreen.kt
+++ b/app/src/main/java/de/readeckapp/ui/settings/UiSettingsScreen.kt
@@ -48,6 +48,7 @@ fun UiSettingsScreen(
     val onClickTheme: () -> Unit = { viewModel.onClickTheme() }
     val onClickDefaultFilter: () -> Unit = { viewModel.onClickDefaultFilter() }
     val onScrollToProgressToggle: (Boolean) -> Unit = { viewModel.onScrollToProgressToggle(it) }
+    val onEInkModeToggle: (Boolean) -> Unit = { viewModel.onEInkModeToggle(it) }
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(key1 = navigationEvent.value) {
@@ -86,6 +87,7 @@ fun UiSettingsScreen(
             onClickTheme = onClickTheme,
             onClickDefaultFilter = onClickDefaultFilter,
             onScrollToProgressToggle = onScrollToProgressToggle,
+            onEInkModeToggle = onEInkModeToggle,
             settingsUiState = settingsUiState
         )
 
@@ -100,6 +102,7 @@ fun UiSettingsView(
     onClickTheme: () -> Unit,
     onClickDefaultFilter: () -> Unit,
     onScrollToProgressToggle: (Boolean) -> Unit,
+    onEInkModeToggle: (Boolean) -> Unit,
     onClickBack: () -> Unit,
 ) {
     Scaffold(
@@ -172,6 +175,22 @@ fun UiSettingsView(
                     onCheckedChange = { onScrollToProgressToggle(it) }
                 )
             }
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.ui_settings_eink_mode_title))
+                    Text(
+                        text = stringResource(R.string.ui_settings_eink_mode_description),
+                        style = Typography.bodySmall
+                    )
+                }
+                Switch(
+                    checked = settingsUiState.eInkMode,
+                    onCheckedChange = { onEInkModeToggle(it) }
+                )
+            }
         }
     }
 }
@@ -185,6 +204,7 @@ fun UiSettingsScreenViewPreview() {
         showDialog = false,
         themeLabel = Theme.SYSTEM.toLabelResource(),
         scrollToProgressEnabled = true,
+        eInkMode = false,
         defaultFilter = DefaultFilter.ALL,
         defaultFilterLabel = DefaultFilter.ALL.toLabelResource(),
         defaultFilterOptions = listOf(),
@@ -198,6 +218,7 @@ fun UiSettingsScreenViewPreview() {
         onClickDefaultFilter = {},
         settingsUiState = settingsUiState,
         onScrollToProgressToggle = {},
+        onEInkModeToggle = {},
     )
 }
 

--- a/app/src/main/java/de/readeckapp/ui/settings/UiSettingsViewModel.kt
+++ b/app/src/main/java/de/readeckapp/ui/settings/UiSettingsViewModel.kt
@@ -33,6 +33,7 @@ class UiSettingsViewModel @Inject constructor(
     val navigationEvent: StateFlow<NavigationEvent?> = _navigationEvent.asStateFlow()
     private val theme = MutableStateFlow(Theme.SYSTEM)
     private val scrollToProgressEnabled = MutableStateFlow(true)
+    private val eInkMode = MutableStateFlow(false)
     private val showDialog = MutableStateFlow(false)
     private val defaultFilter = MutableStateFlow(DefaultFilter.ALL)
     private val showDefaultFilterDialog = MutableStateFlow(false)
@@ -41,15 +42,23 @@ class UiSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             theme.value = settingsDataStore.getTheme()
             scrollToProgressEnabled.value = settingsDataStore.isScrollToProgressEnabled()
+            eInkMode.value = settingsDataStore.isEInkModeEnabled()
             defaultFilter.value = settingsDataStore.getDefaultFilter()
         }
     }
 
 
-    val uiState = combine(theme, scrollToProgressEnabled, showDialog, defaultFilter, showDefaultFilterDialog) { theme, scrollToProgressEnabled, showDialog, defaultFilter, showDefaultFilterDialog ->
+    val uiState = combine(
+        theme,
+        combine(scrollToProgressEnabled, eInkMode) { scroll, eink -> scroll to eink },
+        showDialog,
+        defaultFilter,
+        showDefaultFilterDialog
+    ) { theme, toggles, showDialog, defaultFilter, showDefaultFilterDialog ->
         UiSettingsUiState(
             theme = theme,
-            scrollToProgressEnabled = scrollToProgressEnabled,
+            scrollToProgressEnabled = toggles.first,
+            eInkMode = toggles.second,
             themeOptions = getThemeOptionList(theme),
             showDialog = showDialog,
             themeLabel = theme.toLabelResource(),
@@ -66,6 +75,7 @@ class UiSettingsViewModel @Inject constructor(
                 UiSettingsUiState(
                     theme = Theme.SYSTEM,
                     scrollToProgressEnabled = true,
+                    eInkMode = false,
                     themeOptions = getThemeOptionList(Theme.SYSTEM),
                     showDialog = false,
                     themeLabel = Theme.SYSTEM.toLabelResource(),
@@ -80,6 +90,13 @@ class UiSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             settingsDataStore.setScrollToProgressEnabled(enabled)
             scrollToProgressEnabled.value = settingsDataStore.isScrollToProgressEnabled()
+        }
+    }
+
+    fun onEInkModeToggle(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsDataStore.setEInkModeEnabled(enabled)
+            eInkMode.value = settingsDataStore.isEInkModeEnabled()
         }
     }
 
@@ -160,6 +177,7 @@ class UiSettingsViewModel @Inject constructor(
 data class UiSettingsUiState(
     val theme: Theme,
     val scrollToProgressEnabled: Boolean,
+    val eInkMode: Boolean,
     val themeOptions: List<SelectableOption<Theme>>,
     val showDialog: Boolean,
     @StringRes

--- a/app/src/main/java/de/readeckapp/ui/theme/Theme.kt
+++ b/app/src/main/java/de/readeckapp/ui/theme/Theme.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import de.readeckapp.domain.model.Theme
 import de.readeckapp.ui.theme.sepia.SepiaColorScheme
@@ -33,14 +34,54 @@ private val LightColorScheme = lightColorScheme(
     */
 )
 
+private val EInkColorScheme = lightColorScheme(
+    primary = Color.Black,
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFFDDDDDD),
+    onPrimaryContainer = Color.Black,
+    secondary = Color.Black,
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFDDDDDD),
+    onSecondaryContainer = Color.Black,
+    tertiary = Color.Black,
+    onTertiary = Color.White,
+    tertiaryContainer = Color(0xFFDDDDDD),
+    onTertiaryContainer = Color.Black,
+    error = Color.Black,
+    onError = Color.White,
+    errorContainer = Color(0xFFCCCCCC),
+    onErrorContainer = Color.Black,
+    background = Color.White,
+    onBackground = Color.Black,
+    surface = Color.White,
+    onSurface = Color.Black,
+    surfaceVariant = Color(0xFFEEEEEE),
+    onSurfaceVariant = Color.Black,
+    outline = Color.Black,
+    outlineVariant = Color(0xFFCCCCCC),
+    scrim = Color.Black,
+    inverseSurface = Color.Black,
+    inverseOnSurface = Color.White,
+    inversePrimary = Color.White,
+    surfaceDim = Color(0xFFEEEEEE),
+    surfaceBright = Color.White,
+    surfaceContainerLowest = Color.White,
+    surfaceContainerLow = Color(0xFFEEEEEE),
+    surfaceContainer = Color(0xFFEEEEEE),
+    surfaceContainerHigh = Color(0xFFDDDDDD),
+    surfaceContainerHighest = Color(0xFFCCCCCC),
+)
+
 @Composable
 fun ReadeckAppTheme(
     theme: Theme = Theme.LIGHT,
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
+    eInkMode: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
+        eInkMode -> EInkColorScheme
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && theme in listOf(
             Theme.DARK,
             Theme.LIGHT

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,8 @@ other{}
     <string name="ui_settings_theme_dialog_support_text">Which theme should be used?</string>
     <string name="ui_settings_scroll_to_progress_title">Scroll to reading progress</string>
     <string name="ui_settings_scroll_to_progress_description">When opening a bookmark, automatically scroll to your last reading position.</string>
+    <string name="ui_settings_eink_mode_title">E-ink mode</string>
+    <string name="ui_settings_eink_mode_description">Reduces animations and enables tap zones (tap top/bottom half of the screen to page up/down) for e-ink readers.</string>
     <string name="ui_settings_default_filter_title">Default view</string>
     <string name="ui_settings_default_filter_dialog_support_text">Which view should be shown on startup?</string>
     <string name="default_filter_all">All</string>

--- a/app/src/test/java/de/readeckapp/ui/detail/BookmarkDetailViewModelTest.kt
+++ b/app/src/test/java/de/readeckapp/ui/detail/BookmarkDetailViewModelTest.kt
@@ -58,8 +58,10 @@ class BookmarkDetailViewModelTest {
         every { savedStateHandle.get<String>("bookmarkId") } returns "123"
         every { settingsDataStore.themeFlow } returns MutableStateFlow(Theme.LIGHT.name)
         every { settingsDataStore.zoomFactorFlow } returns MutableStateFlow(100)
+        every { settingsDataStore.eInkModeFlow } returns MutableStateFlow(false)
         coEvery { settingsDataStore.isSyncReadProgressEnabled() } returns true
         coEvery { settingsDataStore.isScrollToProgressEnabled() } returns true
+        coEvery { settingsDataStore.isEInkModeEnabled() } returns false
         viewModel = BookmarkDetailViewModel(updateBookmarkUseCase, bookmarkRepository, assetLoader, settingsDataStore, appScope, savedStateHandle)
     }
 


### PR DESCRIPTION
## Summary

Adds a manual **e-ink mode** toggle under UI Settings. When enabled:

- **Tap zones** in the reader: tap the bottom half of the screen to page down one viewport, tap the top half to page up. Uses non-animated `scrollTo` for clean e-ink refreshes (no ghosting from animation frames).
- **Drag-scrolling disabled** in the reader. Only tap-to-page works, which is the standard e-reader paradigm.
- **Navigation transitions disabled**: instant screen changes instead of fade animations.
- **Header image crossfade disabled**: crisp image load, no fade ghosting.
- **B&W color scheme**: pure black on white for all app chrome (toolbar, cards, FAB, drawer). Distinct gray steps that e-ink panels can actually distinguish.
- **E-ink article template**: pure black text on white, `font-weight: 500` for thicker rendering, black underlined links, no colored elements.

The setting is **off by default**: existing users see zero behavior change.

## Implementation

Follows the existing `scrollToProgressEnabled` toggle pattern:

- `SettingsDataStore` + `SettingsDataStoreImpl`: new `eInkMode` pref (SharedPreferences-backed, with reactive `StateFlow`)
- `UiSettingsViewModel` / `UiSettingsScreen`: new `Switch` row
- `BookmarkDetailScreen`: invisible overlay `Box` on top of the content intercepts taps (WebView consumes touches, so the overlay must sit above it); `verticalScroll(scrollState, enabled = !eInkMode)` disables drag-scrolling
- `MainActivity`: conditional `NavHost` transitions; `ReadeckAppTheme` accepts `eInkMode` to switch color scheme
- `html_template_eink.html`: new Sakura.css variant stripped of all color
- `BookmarkDetailViewModel`: template flow switches to e-ink template when mode is on

## Known limitations

- **Site-name click in reader does not work in e-ink mode.** The tap-zone overlay covers the full screen, so the clickable site-name row (which opens the article URL in a browser) is intercepted. The FAB menu and back button are unaffected.
- **`BookmarkDetailViewModel` reads eInkMode once in init** (non-reactive), consistent with the existing `scrollToProgressEnabled` pattern. Toggling the setting while reading an article takes effect on next article open.

## Test plan

- [x] `./gradlew compileGithubReleaseDebugKotlin` passes
- [x] `./gradlew testGithubReleaseDebugUnitTest` all tests pass
- [x] Manual: toggle e-ink mode on, nav transitions are instant
- [x] Manual: open an article, tap bottom half pages down, tap top half pages up
- [x] Manual: e-ink mode off is identical to current behavior
- [x] Manual: B&W color scheme applied to list, settings, and reader
- [x] Manual: article content is pure black on white with thicker text
- [x] Manual: drag-scrolling is disabled in the reader when e-ink mode is on

## Files changed

14 files, +427/-42 lines. No new modules, no new dependencies.