### PR TITLE
fix: normalize trailing slashes in server URLs

### DIFF
--- a/app/src/main/java/de/readeckapp/io/rest/UrlInterceptor.kt
+++ b/app/src/main/java/de/readeckapp/io/rest/UrlInterceptor.kt
@@ -24,9 +24,11 @@ class UrlInterceptor @Inject constructor(
             throw IOException("baseUrl is not set")
         } else {
             // Modify the request's URL to use the current baseUrl
+            val cleanBaseUrl = baseUrl.trimEnd('/')
+
             val newUrl = originalUrl.replace(
                 "http://readeck.invalid",
-                baseUrl
+                cleanBaseUrl
             )
             val newRequest: Request = request.newBuilder()
                 .url(newUrl)

--- a/app/src/main/java/de/readeckapp/ui/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/de/readeckapp/ui/settings/AccountSettingsViewModel.kt
@@ -96,7 +96,7 @@ class AccountSettingsViewModel @Inject constructor(
                 // Save URL early so it's persisted and the DataStore flows get updated
                 settingsDataStore.saveUrl(url)
 
-                val baseUri = url.removeSuffix("/api")
+                val baseUri = url.trimEnd('/').removeSuffix("/api")
                 val authEndpoint = "$baseUri/authorize".toUri()
                 val tokenEndpoint = "$baseUri/api/oauth/token".toUri()
                 val registrationEndpoint = "$baseUri/api/oauth/client".toUri()

--- a/app/src/test/java/de/readeckapp/io/rest/UrlInterceptorTest.kt
+++ b/app/src/test/java/de/readeckapp/io/rest/UrlInterceptorTest.kt
@@ -1,0 +1,77 @@
+package de.readeckapp.io.rest
+
+import de.readeckapp.io.prefs.SettingsDataStore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.MutableStateFlow
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.IOException
+
+class UrlInterceptorTest {
+    private val settingsDataStore = mockk<SettingsDataStore>()
+
+    private fun runInterceptor(userUrl: String?, originalUrl: String = "http://readeck.invalid/api/bookmarks"): String {
+        val flow = MutableStateFlow(userUrl)
+        every { settingsDataStore.urlFlow } returns flow
+
+        val interceptor = UrlInterceptor(settingsDataStore)
+        val request = Request.Builder().url(originalUrl).build()
+
+        val captured = slot<Request>()
+        val dummyResponse = mockk<Response>(relaxed = true)
+
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(capture(captured)) } returns dummyResponse
+        }
+
+        interceptor.intercept(chain)
+
+        return captured.captured.url.toString()
+    }
+
+    @Test
+    fun testTrailingSlashMustNotCreateDoubleSlash() {
+        val url = runInterceptor("http://192.168.1.246:8000/")
+        assertEquals("http://192.168.1.246:8000/api/bookmarks", url)
+    }
+
+    @Test
+    fun testNoTrailingSlashWorksCorrectly() {
+        val url = runInterceptor("http://192.168.1.246:8000")
+        assertEquals("http://192.168.1.246:8000/api/bookmarks", url)
+    }
+
+    @Test
+    fun testDoubleTrailingSlashIsHandled() {
+        val url = runInterceptor("http://192.168.1.246:8000//")
+        assertEquals("http://192.168.1.246:8000/api/bookmarks", url)
+    }
+
+    @Test
+    fun testHttpsUrlWorks() {
+        val url = runInterceptor("https://readeck.example.com/")
+        assertEquals("https://readeck.example.com/api/bookmarks", url)
+    }
+
+    @Test
+    fun testBaseUrlWithPortAndPath() {
+        val url = runInterceptor("http://myserver.com:3000/custom/")
+        assertEquals("http://myserver.com:3000/custom/api/bookmarks", url)
+    }
+
+    @Test(expected = IOException::class)
+    fun testEmptyUrlThrows() {
+        runInterceptor("")
+    }
+
+    @Test(expected = IOException::class)
+    fun testNullUrlThrows() {
+        runInterceptor(null)
+    }
+}


### PR DESCRIPTION
A trailing slash in the Readeck URL when adding an account (i.e. https://readeck.local/) caused double slashes in API requests (i.e. //api/bookmarks), leading to a 'JSON deserialization' error on login. Trim trailing slashes in both UrlInterceptor and AccountSettingsViewModel endpoint construction. 

Adds a UrlInterceptor test to confirm this works.

Closes #173

(Note: I am not really a Java/Kotlin dev, so while this seems to work, I'd appreciate feedback if it doesn't).