### PR TITLE
chore: update Retrofit docs information

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This project uses the following technologies:
 *   [Jetpack Navigation](https://developer.android.com/jetpack/compose/navigation)
 *   [Timber](https://github.com/JakeWharton/timber)
 *   [Hilt](https://dagger.dev/hilt/) for dependency injection
-*   [Retrofit](https://square.github.com/retrofit/) for network requests
+*   [Retrofit](https://lysine.dev/retrofit/) for network requests
 *   [Room](https://developer.android.com/training/data-storage/room) for local data persistence
 *   ...
 


### PR DESCRIPTION
The current Retrofit link leads to server not found. Looks like the latest version of Retrofit documentation is at https://lysine.dev/retrofit/

The source code is at https://github.com/lysine-dev/retrofit but I figure linking to the docs makes more sense.